### PR TITLE
Enable Eirini to run on a BOSH VM

### DIFF
--- a/jobs/opi/spec
+++ b/jobs/opi/spec
@@ -5,6 +5,8 @@ templates:
   opi_ctl.erb: bin/opi_ctl
   opi_as_vcap.erb: bin/opi_as_vcap
   opi.yml.erb: config/opi.yml
+  kube.conf.erb: config/kube.conf
+  node_ca.crt.erb: config/node_ca.crt
   certs/cc-ca.crt.erb: certs/cc-ca.crt
   certs/cc.crt.erb: certs/cc.crt
   certs/cc.key.erb: certs/cc.key
@@ -57,3 +59,12 @@ properties:
     description: "Cloud Controller key"
   opi.cc_ca:
     description: "Cloud Controller CA cert"
+
+  opi.k8s.host_url:
+    description: "URL of k8s node"
+  opi.k8s.node_ca:
+    description: "CA certificate for k8s node"
+  opi.k8s.service_account.name:
+    description: "Username of service account Eirini will operate on k8s with"
+  opi.k8s.service_account.token:
+    description: "Token of service account Eirini will operate on k8s with"

--- a/jobs/opi/templates/kube.conf.erb
+++ b/jobs/opi/templates/kube.conf.erb
@@ -1,0 +1,20 @@
+<% if_p("opi.k8s.host_url", "opi.k8s.node_ca", "opi.k8s.service_account.name", "opi.k8s.service_account.token") do |host_url, node_ca, service_username, service_token| %>
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: /var/vcap/jobs/opi/config/node_ca.crt
+    server: <%= host_url %>
+  name: opi-cluster
+contexts:
+- context:
+    cluster: opi-cluster
+    user: <%= service_username %>
+  name: opi-cluster
+current-context: opi-cluster
+kind: Config
+preferences: {}
+users:
+- name: <%= service_username %>
+  user:
+    token: <%= service_token %>
+<% end %>

--- a/jobs/opi/templates/node_ca.crt.erb
+++ b/jobs/opi/templates/node_ca.crt.erb
@@ -1,1 +1,3 @@
-<%= p("opi.k8s.node_ca") %>
+<% if_p("opi.k8s.node_ca") do |node_ca| %>
+<%= node_ca %>
+<% end %>

--- a/jobs/opi/templates/node_ca.crt.erb
+++ b/jobs/opi/templates/node_ca.crt.erb
@@ -1,0 +1,1 @@
+<%= p("opi.k8s.node_ca") %>

--- a/jobs/opi/templates/opi.yml.erb
+++ b/jobs/opi/templates/opi.yml.erb
@@ -6,7 +6,7 @@ opi:
   cc_internal_api: <%= p("opi.cc_internal_api") %>
   cc_uploader_ip: <%= p("opi.cc_uploader_ip") %>
   registry_address: <%= p("opi.registry_address") %>
-  eirini_address: <%= p("opi.eirini_address") %>
+  eirini_address: <%= p("opi.eirini_address", "http://" + spec.ip + ":8085") %>
   stager_image: <%= p("opi.stager_image") %>
   metrics_source_address: <%= p("opi.metrics_source_address") %>
   loggregator_address: <%= p("opi.loggregator_address") %>
@@ -16,3 +16,8 @@ opi:
   cc_cert_path: /var/vcap/jobs/opi/certs/cc.crt
   cc_key_path: /var/vcap/jobs/opi/certs/cc.key
   cc_ca_path: /var/vcap/jobs/opi/certs/cc-ca.crt
+<% if_p("opi.k8s.host_url", "opi.k8s.node_ca", "opi.k8s.service_account.name", "opi.k8s.service_account.token") do %>
+  kube_config_path: /var/vcap/jobs/opi/config/kube.conf
+<% end.else do %>
+  kube_config_path: ~
+<% end %>

--- a/packages/eirini/packaging
+++ b/packages/eirini/packaging
@@ -6,6 +6,9 @@ export GOPATH=$BOSH_INSTALL_TARGET
 
 export GOROOT=$(readlink -nf /var/vcap/packages/golang)
 export PATH=$GOROOT/bin:$PATH
+
+export GOCACHE="${GOROOT}/cache"
+
 pushd ${BOSH_INSTALL_TARGET}/src/code.cloudfoundry.org/eirini/cmd/opi
   go build -o ${BOSH_INSTALL_TARGET}/bin/opi
 popd


### PR DESCRIPTION
This PR enables Eirini to run on a BOSH-managed VM.  Recently, Eirini was modified to be able to run outside the k8s cluster (see https://github.com/cloudfoundry-incubator/eirini/pull/52). This PR hooks that ability into the bosh release so that Eirini can run on a BOSH VM.

This is accomplished by generating a kube config file from the following new spec properties:
- opi.k8s.host_url
- opi.k8s.node_ca
- opi.k8s.service_account.name
- opi.k8s.service_account.token

If those values are specified, kube config and CA certificate files are generated on the BOSH VM and hooked into the opi config.

This PR also bumps the Eirini submodule to be able to take advantage of the out-of-cluster support.