### PR TITLE
Add deployment instructions and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 This is a BOSH release for [eirini](https://code.cloudfoundry.org/eirini).
 
+## Deploying CF+Eirini with BOSH
+
+1. Ensure you have the following utilities:
+  - `jq`
+  - `bosh`
+  - `credhub`
+  - `kubectl`
+1. Create a k8s cluster and add it as the current context to your kubectl config.
+1. Ensure that the BOSH & CredHub CLI connection environment variables are properly set.
+1. Run `scripts/pre-deploy-configure-k8s.sh`
+1. Create and upload the following BOSH releases:
+    - [`bits-service-release`](https://github.com/cloudfoundry-incubator/bits-service-release)
+        - At least git tag > `2.26.0-dev.8`
+    - This BOSH release
+1. Deploy `cf-deployment` with the following ops files (in this order):
+    - `<CF_DEPLOYMENT>/operations/bits-service/use-bits-service.yml`
+    - `eirini-bosh-release/operations/add-eirini.yml`
+1. Run `scripts/post-deploy-configure-k8s.sh <LB_CA_CERT_VALUE> <SYSTEM_DOMAIN>`
+    - The value of `LB_CA_CERT_VALUE` must be the CA of the cert of whatever in your deployment is terminating TLS (usually either an IaaS load balancer or the gorouter itself)
+
 ## Contributing
 
 1. Fork this project into your GitHub organisation or username

--- a/operations/add-eirini.yml
+++ b/operations/add-eirini.yml
@@ -1,0 +1,115 @@
+# Add eirini
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: eirini
+    release: eirini
+    azs: [z1]
+    instances: 1
+    vm_type: minimal
+    stemcell: default
+    networks:
+    - name: default
+    jobs:
+    - name: opi
+      release: eirini
+      properties:
+        opi:
+          kube_namespace: eirini
+          kube_service_host: ""
+          kube_service_port: ""
+          registry_address: registry.((system_domain))
+          nats_password: ((nats_password))
+          nats_ip: q-s0.nats.default.cf.bosh
+          certs_secret_name: cc-certs-secret
+          cc_internal_api: https://cloud-controller-ng.service.cf.internal:9023
+          cc_uploader_ip: ""
+          stager_image: eirini/recipe
+          metrics_source_address: ""
+          loggregator_address: localhost:3458
+          loggregator_cert: ((loggregator_tls_agent.certificate))
+          loggregator_key: ((loggregator_tls_agent.private_key))
+          loggregator_ca: ((loggregator_tls_agent.certificate))
+          cc_cert: ((cc_bridge_tps.certificate))
+          cc_key: ((cc_bridge_tps.private_key))
+          cc_ca: ((service_cf_internal_ca.certificate))
+          k8s:
+            host_url: ((k8s_host_url))
+            service_account:
+              name: ((k8s_service_username))
+              token: ((k8s_service_token))
+            node_ca: ((k8s_node_ca))
+
+# Attach a persistent disk to bits-service VM to store eirinifs
+- type: replace
+  path: /instance_groups/name=bits/persistent_disk_type?
+  value: 5GB
+
+# Enable Docker registry on bits-service (used by OPI)
+- type: replace
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/enable_registry?
+  value: true
+- type: replace
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/registry_endpoint?
+  value: "https://registry.((system_domain))"
+- type: replace
+  path: /instance_groups/name=bits/jobs/name=route_registrar/properties/route_registrar/routes/name=bits-service/uris/-
+  value: registry.((system_domain))
+- type: replace
+  path: /variables/name=bits_service_ssl/options/alternative_names/-
+  value: registry.((system_domain))
+
+# Add eirinifs job to the bits-service to copy the tarball into the bits-service VM
+- type: replace
+  path: /instance_groups/name=bits/jobs/name=eirinifs?
+  value:
+    name: eirinifs
+    release: eirini
+- type: replace
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/rootfs?/blobstore_type?
+  value: local
+
+- type: replace
+  path: /releases/name=bits-service/version?
+  value: latest
+- type: replace
+  path: /releases/name=eirini?/version?
+  value: latest
+
+# Enable OPI in CC
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/enabled?
+  value: true
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/url?
+  value: http://q-s0.eirini.default.cf.bosh:8085
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/opi_staging?
+  value: false
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/enabled?
+  value: true
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/url?
+  value: http://q-s0.eirini.default.cf.bosh:8085
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/opi_staging?
+  value: false
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/enabled?
+  value: true
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/url?
+  value: http://q-s0.eirini.default.cf.bosh:8085
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/opi_staging?
+  value: false
+
+# Make loggregator agent cert validate correctly for fluentd in k8s nodes
+- type: replace
+  path: /variables/name=loggregator_tls_agent/options/alternative_names?
+  value:
+    - localhost
+    - metron

--- a/scripts/post-deploy-configure-k8s.sh
+++ b/scripts/post-deploy-configure-k8s.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+LB_CA_CERT="$1"
+SYSTEM_DOMAIN="$2"
+
+BOSH_ENV_NAME="$(bosh env --json | jq .Tables[0].Rows[0].name -r)"
+DOPPLER_ADDRESS="$(bosh -d cf vms | grep doppler | cut -d$'\t' -f4 | head -n 1)"
+
+echo "Creating secret for the load balancer CA cert..."
+kubectl apply -f <(kubectl create secret generic lb-ca-cert \
+  --from-literal=ca.crt="$LB_CA_CERT" \
+  --dry-run \
+  --save-config \
+  -o yaml)
+kubectl apply -f <(cat <<EOD
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: add-lb-cert-to-nodes
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      name: add-lb-cert-to-nodes
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: add-lb-cert-to-nodes
+    spec:
+      initContainers:
+      - name: create-docker-certs-directory-on-node
+        image: ubuntu:xenial
+        securityContext:
+          runAsUser: 0
+          privileged: true
+        volumeMounts:
+        - name: etcdocker
+          mountPath: /etc/docker
+        command: ["bash"]
+        args: ["-cx", "mkdir -p /etc/docker/certs.d/registry.${SYSTEM_DOMAIN}"]
+      containers:
+      - name: add-ca-cert-to-nodes-docker-trust
+        image: ubuntu:xenial
+        securityContext:
+          runAsUser: 0
+          privileged: true
+        volumeMounts:
+        - name: etcdocker
+          mountPath: /etc/docker
+        - name: lb-ca-cert
+          mountPath: /etc/lb-ca-cert
+        command: ["bash"]
+        args: ["-cx", "cp /etc/lb-ca-cert/ca.crt /etc/docker/certs.d/registry.${SYSTEM_DOMAIN}/ && sleep infinity"]
+      volumes:
+      - name: etcdocker
+        hostPath:
+          path: /etc/docker
+      - name: lb-ca-cert
+        secret:
+          secretName: lb-ca-cert
+EOD)
+
+echo "Creating loggregator certs secret..."
+kubectl create secret generic loggregator-tls-certs-secret \
+  --from-literal=internal-ca-cert="$(credhub get -n /${BOSH_ENV_NAME}/cf/loggregator_tls_agent -j | jq -r .value.ca)" \
+  --from-literal=loggregator-agent-cert-key="$(credhub get -n /${BOSH_ENV_NAME}/cf/loggregator_tls_agent -j | jq -r .value.private_key)" \
+  --from-literal=loggregator-agent-cert="$(credhub get -n /${BOSH_ENV_NAME}/cf/loggregator_tls_agent -j | jq -r .value.certificate)"
+
+echo "Creating loggregator fluentd ConfigMap..."
+kubectl apply -f <(cat <<EOD
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-conf
+data:
+  fluentd-conf-contents: |
+    <match fluent.**>
+      @type null
+    </match>
+
+    <source>
+      @type tail
+      @id in_tail_container_logs
+      path /var/log/containers/*.log
+      pos_file /var/log/fluentd-containers.log.pos
+      tag kubernetes.*
+      format json
+      read_from_head true
+      refresh_interval 1
+      time_format %Y-%m-%dT%H:%M:%S.%N%:z
+    </source>
+
+    <filter kubernetes.**>
+      @type kubernetes_metadata
+    </filter>
+
+    <match **>
+      type loggregator
+      loggregator_target localhost:3458
+      loggregator_cert_file /fluentd/certs/agent.crt
+      loggregator_key_file /fluentd/certs/agent.key
+      loggregator_ca_file /fluentd/certs/ca.crt
+      eirini_namespace eirini
+    </match>
+
+    <match kubernetes.var.log.containers.**eirini**.log>
+      @type stdout
+    </match>
+
+    <match kubernetes.var.log.containers.**.log>
+      @type null
+    </match>
+EOD)
+
+echo "Creating loggregator fluentd DaemonSet..."
+kubectl apply -f <(cat <<EOD
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: loggregator-fluentd
+spec:
+  selector:
+    matchLabels:
+      name: loggregator-fluentd
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: loggregator-fluentd
+    spec:
+      serviceAccountName: "opi-service-account"
+      initContainers:
+      - name: config-copier
+        image: alpine:latest
+        command: [ "/bin/sh", "-c", "cp /input/fluent.conf /output" ]
+        volumeMounts:
+        - name: fluentd-conf
+          mountPath: /input
+        - name: config-volume
+          mountPath: /output
+          readOnly: false
+      containers:
+      - name: loggregator-fluentd
+        image: eirini/loggregator-fluentd:0.2.0
+        imagePullPolicy: Always
+        env:
+        - name: FLUENT_UID
+          value: "0"
+        - name: GRPC_VERBOSITY
+          value: DEBUG
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: vardata
+          mountPath: /var/data
+        - name: varlog
+          mountPath: /var/log
+        - name: containers
+          mountPath: /var/lib/docker/containers
+        - name: config-volume
+          mountPath: /fluentd/etc/
+          readOnly: false
+        - name: loggregator-tls-certs
+          mountPath: /fluentd/certs
+          readOnly: true
+      - name: loggregator-agent
+        image: loggregator/agent
+        imagePullPolicy: Always
+        env:
+        - name: AGENT_METRIC_SOURCE_ID
+          value: scf/daemonset/loggregator-fluentd
+        - name: ROUTER_ADDR
+          value: ${DOPPLER_ADDRESS}:8082
+        - name: ROUTER_ADDR_WITH_AZ
+          value: ${DOPPLER_ADDRESS}:8082
+        - name: AGENT_PPROF_PORT
+          value: "6062"
+        - name: AGENT_HEALTH_ENDPOINT_PORT
+          value: "6063"
+        ports:
+        - name: health
+          containerPort: 6063
+        volumeMounts:
+        - name: loggregator-tls-certs
+          mountPath: /srv/certs
+          readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: vardata
+        hostPath:
+          path: /var/data
+      - name: config-volume
+        emptyDir: {}
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: containers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluentd-conf
+        configMap:
+          name: fluentd-conf
+          items:
+          - key: fluentd-conf-contents
+            path: fluent.conf
+      - name: loggregator-tls-certs
+        secret:
+          secretName: loggregator-tls-certs-secret
+          items:
+            - key: loggregator-agent-cert
+              path: agent.crt
+            - key: loggregator-agent-cert-key
+              path: agent.key
+            - key: internal-ca-cert
+              path: ca.crt
+EOD)
+
+echo "Done"

--- a/scripts/pre-deploy-configure-k8s.sh
+++ b/scripts/pre-deploy-configure-k8s.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -ueo pipefile
+
+k8s_service_account=opi-service-account
+
+echo "Creating service account '$k8s_service_account'..."
+kubectl apply -f <(kubectl create serviceaccount $k8s_service_account -o yaml --save-config --dry-run)
+
+echo "Creating cluster-admin role binding for the service account..."
+kubectl apply -f <(kubectl create clusterrolebinding opi-cluster-admin --clusterrole=custer-admin --serviceaccount="default:$k8s_service_account" -o yaml --save-config --dry-run)
+
+echo "Retrieving the service account's token secret..."
+service_account_token_secret="$(kubectl get serviceaccount ${k8s_service_account} -o jsonpath='{.secrets[0].name}')"
+k8s_service_token="$(kubectl get secret ${service_account_token_secret} -o jsonpath='{.data.token}' | base64 -D)"
+
+echo "Extracting CA and server address from current kubectl context..."
+k8s_node_ca="$(bosh int <(kubectl config view --raw --minify) --path=/clusters/0/cluster/certificate-authority-data | base64 -D)"
+k8s_host_url="$(bosh int <(kubectl config view --raw --minify) --path=/clusters/0/cluster/server)"
+
+echo "Retrieving the currently targeted BOSH environment's name..."
+bosh_env_name="$(bosh env --json | jq .Tables[0].Rows[0].name -r)"
+
+echo "Creating credhub entries with k8s cluster info..."
+credhub set --name=/$bosh_env_name/cf/k8s_host_url --value="${k8s_host_url}" -t value
+credhub set --name=/$bosh_env_name/cf/k8s_service_username --value="${k8s_service_account}" -t value
+credhub set --name=/$bosh_env_name/cf/k8s_service_token --value="${k8s_service_token}" -t value
+credhub set --name=/$bosh_env_name/cf/k8s_node_ca --value="${k8s_node_ca}" -t value
+
+echo
+echo "Done"


### PR DESCRIPTION
This PR includes adds instructions to README.md for how this release can be deployed with BOSH.

We've also added some scripts and an ops file to make the setup process easier.

This is intended to be a rough first stab at this. It doesn't attempt to be robust or cover all edge cases (and it explicitly turns off Eirini-based staging). We figured that even if folks run into problems running these scripts, it may help to have them for reference, and we can improve the quality over time.

Thanks,
Jen + @jspawar 