### PR TITLE
Add a version to eirinifs blob

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,4 @@
-eirini/eirinifs.tar:
+eirini/eirinifs-v34.0.0.tar:
   size: 1085480960
   object_id: 0b0fccd9-4b57-4319-4d32-71148671a7c0
   sha: 122dfa34f61396998a6f84a5c5e199e6a3040099

--- a/packages/eirinifs/packaging
+++ b/packages/eirinifs/packaging
@@ -1,3 +1,3 @@
 set -e
 
-cp eirini/eirinifs.tar ${BOSH_INSTALL_TARGET}
+cp eirini/eirinifs-v*.tar ${BOSH_INSTALL_TARGET}/eirinifs.tar

--- a/packages/eirinifs/spec
+++ b/packages/eirinifs/spec
@@ -2,4 +2,4 @@
 name: eirinifs
 
 files:
-- eirini/eirinifs.tar
+- eirini/eirinifs-v*.tar


### PR DESCRIPTION
Without a version on the name of the eirinifs blob, it can be hard to match up the blob with a particular version of source code.

We added the string `-v34.0.0` with the intention that it matches up with the version of the eirinifs GitHub release. Then we can tie the blob to the source easily.

We've validated that the bosh release still can be created and deployed successfully with bosh after this change.

Thanks,
Jen & @jpalermo