### PR TITLE
Fix rendering issue with TLS properties

### DIFF
--- a/jobs/opi/templates/certs/client-ca.crt.erb
+++ b/jobs/opi/templates/certs/client-ca.crt.erb
@@ -1,1 +1,3 @@
-<%= p("opi.client_ca") %>
+<% if_p("opi.client_ca") do |client_ca| %>
+<%= client_ca %>
+<% end %>

--- a/jobs/opi/templates/certs/server.crt.erb
+++ b/jobs/opi/templates/certs/server.crt.erb
@@ -1,1 +1,3 @@
-<%= p("opi.server_cert") %>
+<% if_p("opi.server_cert") do |server_cert| %>
+<%= server_cert %>
+<% end %>

--- a/jobs/opi/templates/certs/server.key.erb
+++ b/jobs/opi/templates/certs/server.key.erb
@@ -1,1 +1,3 @@
-<%= p("opi.server_key") %>
+<% if_p("opi.server_key") do |server_key| %>
+<%= server_key %>
+<% end %>


### PR DESCRIPTION
Minor tweak to make the new properties we introduced for TLS support actually optional (oops!)

Modified templates for TLS-related files to render contents only if their respective properties are actually set.

Thanks!