### PR TITLE
[Do not merge] Stawman first pass at making configure-eirini errand work on a BOSH-managed env

### DIFF
--- a/jobs/configure-eirini/spec
+++ b/jobs/configure-eirini/spec
@@ -26,8 +26,10 @@ properties:
     description: "CF's doppler address, used to stream application logs"
   eirini.doppler_address_with_az:
     description: "CF's doppler address for the current AZ, used to stream application logs"
-  eirini.namespace:
-    description: "Kubernetes namespace that Eirini has been configured to target"
+  opi.workloads_namespace:
+    description: "Kubernetes namespace where to run deployments and tasks"
+  opi.system_namespace:
+    description: "Kubernetes namespace where to deploy Eirini components"
   eirini.service_account:
     description: "The service account used by fluentd to access pod information"
   loggregator.ca-cert:

--- a/jobs/configure-eirini/spec
+++ b/jobs/configure-eirini/spec
@@ -16,6 +16,8 @@ templates:
   loggregator-agent.key.erb: config/loggregator-agent.key
 
 properties:
+  eirini.loggregator_agent_image:
+    description: "The docker image used by Eirini to forward Kubernetes container logs"
   eirini.fluentd_image:
     description: "The docker image used by Eirini to consume Kubernetes container logs"
   eirini.config_copier_image:

--- a/jobs/configure-eirini/spec
+++ b/jobs/configure-eirini/spec
@@ -11,14 +11,26 @@ templates:
   eirini-daemonset.yaml.erb: config/eirini-daemonset.yaml
   fluentd-configmap.yaml.erb: config/fluentd-configmap.yaml
 
+  loggregator-ca.crt.erb: config/loggregator-ca.crt
+  loggregator-agent.crt.erb: config/loggregator-agent.crt
+  loggregator-agent.key.erb: config/loggregator-agent.key
+
 properties:
   eirini.fluentd_image:
     description: "The docker image used by Eirini to consume Kubernetes container logs"
-  eirini.cert_copier_image:
-    description: "The docker image used by Eirini to register the image registry CA cert with Docker, on each Kubernetes node"
+  eirini.config_copier_image:
+    description: "The docker image used to copy the fluentd config to an accessible volume mount"
   eirini.doppler_address:
-    description: "SCF's doppler address, used to stream application logs"
+    description: "CF's doppler address, used to stream application logs"
   eirini.doppler_address_with_az:
-    description: "SCF's doppler address for the current AZ, used to stream application logs"
-  eirini.registry.address:
-    description: "Eirini's image registry public address"
+    description: "CF's doppler address for the current AZ, used to stream application logs"
+  eirini.namespace:
+    description: "Kubernetes namespace that Eirini has been configured to target"
+  eirini.service_account:
+    description: "The service account used by fluentd to access pod information"
+  loggregator.ca-cert:
+    description: "CA certificate that is signing the server certificate of the target doppler and loggregator agent"
+  loggregator.agent-cert:
+    description: "Certificate of the loggregator agent"
+  loggregator.agent-cert-key:
+    description: "Private key of the loggregator agent"

--- a/jobs/configure-eirini/templates/eirini-daemonset.yaml.erb
+++ b/jobs/configure-eirini/templates/eirini-daemonset.yaml.erb
@@ -56,7 +56,7 @@ spec:
           mountPath: /fluentd/certs
           readOnly: true
       - name: loggregator-agent
-        image: loggregator/agent
+        image: <%= p('eirini.loggregator_agent_image') %>
         imagePullPolicy: Always
         env:
         - name: AGENT_METRIC_SOURCE_ID

--- a/jobs/configure-eirini/templates/eirini-daemonset.yaml.erb
+++ b/jobs/configure-eirini/templates/eirini-daemonset.yaml.erb
@@ -14,27 +14,10 @@ spec:
       labels:
         name: eirini-loggregator-fluentd
     spec:
-      serviceAccountName: "eirini"
+      serviceAccountName: "<%= p('eirini.service_account') %>"
       initContainers:
-      - name: copy-certs
-        env:
-        - name: INTERNAL_CA_CERT
-          valueFrom:
-            secretKeyRef:
-              key: internal-ca-cert
-              name: "<%= p('scf.secrets_generation_name') %>"
-        - name: REGISTRY
-          value: "<%= p('eirini.registry.address') %>"
-        - name: SCF_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        image: "<%= p('eirini.cert_copier_image') %>"
-        volumeMounts:
-        - name: host-docker
-          mountPath: /workspace/docker
       - name: config-copier
-        image: "<%= p('eirini.cert_copier_image') %>"
+        image: "<%= p('eirini.config_copier_image') %>"
         command: [ "/bin/sh", "-c", "cp /input/fluent.conf /output" ]
         volumeMounts:
         - name: fluentd-conf
@@ -63,18 +46,15 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
-        - name: varvcapstore
-          mountPath: /var/vcap/store
-          readOnly: true
-        - name: varvcapdata
-          mountPath: /var/vcap/data
-          readOnly: true
-        - name: loggregator-tls-certs
-          mountPath: /fluentd/certs
+        - name: varvcapstoredockercontainers
+          mountPath: /var/vcap/store/docker/docker/containers
           readOnly: true
         - name: config-volume
           mountPath: /fluentd/etc/
           readOnly: false
+        - name: loggregator-tls-certs
+          mountPath: /fluentd/certs
+          readOnly: true
       - name: loggregator-agent
         image: loggregator/agent
         imagePullPolicy: Always
@@ -107,15 +87,12 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
-      - name: varvcapstore
+      - name: varvcapstoredockercontainers
         hostPath:
-          path: /var/vcap/store/
-      - name: varvcapdata
-        hostPath:
-          path: /var/vcap/data/
+          path: /var/vcap/store/docker/docker/containers
       - name: loggregator-tls-certs
         secret:
-          secretName: <%= p('scf.secrets_generation_name') %>
+          secretName: loggregator-tls-certs-secret
           items:
             - key: loggregator-agent-cert
               path: agent.crt

--- a/jobs/configure-eirini/templates/fluentd-configmap.yaml.erb
+++ b/jobs/configure-eirini/templates/fluentd-configmap.yaml.erb
@@ -28,9 +28,9 @@ data:
       loggregator_cert_file /fluentd/certs/agent.crt
       loggregator_key_file /fluentd/certs/agent.key
       loggregator_ca_file /fluentd/certs/ca.crt
-      eirini_namespace <%= p("eirini.namespace") %>
+      eirini_namespace <%= p("opi.workloads_namespace") %>
     </match>
-    <match kubernetes.var.log.containers.**<%= p("eirini.namespace") %>**.log>
+    <match kubernetes.var.log.containers.**<%= p("opi.workloads_namespace") %>**.log>
       @type stdout
     </match>
     <match kubernetes.var.log.containers.**.log>

--- a/jobs/configure-eirini/templates/fluentd-configmap.yaml.erb
+++ b/jobs/configure-eirini/templates/fluentd-configmap.yaml.erb
@@ -28,9 +28,9 @@ data:
       loggregator_cert_file /fluentd/certs/agent.crt
       loggregator_key_file /fluentd/certs/agent.key
       loggregator_ca_file /fluentd/certs/ca.crt
-      eirini_namespace eirini
+      eirini_namespace <%= p("eirini.namespace") %>
     </match>
-    <match kubernetes.var.log.containers.**eirini**.log>
+    <match kubernetes.var.log.containers.**<%= p("eirini.namespace") %>**.log>
       @type stdout
     </match>
     <match kubernetes.var.log.containers.**.log>

--- a/jobs/configure-eirini/templates/loggregator-agent.crt.erb
+++ b/jobs/configure-eirini/templates/loggregator-agent.crt.erb
@@ -1,0 +1,1 @@
+<%= p("loggregator.agent-cert") %>

--- a/jobs/configure-eirini/templates/loggregator-agent.key.erb
+++ b/jobs/configure-eirini/templates/loggregator-agent.key.erb
@@ -1,0 +1,1 @@
+<%= p("loggregator.agent-cert-key") %>

--- a/jobs/configure-eirini/templates/loggregator-ca.crt.erb
+++ b/jobs/configure-eirini/templates/loggregator-ca.crt.erb
@@ -1,0 +1,1 @@
+<%= p("loggregator.ca-cert") %>

--- a/jobs/configure-eirini/templates/run.erb
+++ b/jobs/configure-eirini/templates/run.erb
@@ -7,7 +7,10 @@ echo "Configuring Eirini"
 export KUBECONFIG="/var/vcap/jobs/opi/config/kube.conf"
 kubectl="/var/vcap/packages/kubectl/bin/kubectl"
 
+$kubectl apply -f <(kubectl create namespace "<%= p('opi.system_namespace') %>" --dry-run --save-config -o yaml)
+
 $kubectl apply -f <($kubectl create secret generic loggregator-tls-certs-secret \
+  -n "<%= p('opi.system_namespace') %>" \
   --dry-run \
   --save-config \
   --from-file=internal-ca-cert=/var/vcap/jobs/configure-eirini/config/loggregator-ca.crt \
@@ -16,7 +19,7 @@ $kubectl apply -f <($kubectl create secret generic loggregator-tls-certs-secret 
   -o yaml)
 
 echo "Setting up fluentd configuration"
-$kubectl apply -f /var/vcap/jobs/configure-eirini/config/fluentd-configmap.yaml
+$kubectl apply -f /var/vcap/jobs/configure-eirini/config/fluentd-configmap.yaml -n "<%= p('opi.system_namespace') %>"
 
 echo "Setting up Eirini daemonsets"
-$kubectl apply -f /var/vcap/jobs/configure-eirini/config/eirini-daemonset.yaml
+$kubectl apply -f /var/vcap/jobs/configure-eirini/config/eirini-daemonset.yaml -n "<%= p('opi.system_namespace') %>"

--- a/jobs/configure-eirini/templates/run.erb
+++ b/jobs/configure-eirini/templates/run.erb
@@ -1,27 +1,22 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-status "Configuring Eirini"
+set -euxo pipefail
 
-kubectl=/var/vcap/packages/kubectl/bin/kubectl
+echo "Configuring Eirini"
 
-scf_secrets="$(${kubectl} get secret "<%= p("scf.secrets_generation_name") %>" --namespace="$KUBERNETES_NAMESPACE" --export -o yaml | grep -E 'cc-.*|internal-ca-.*')"
-cat <<EOT >> secret.yml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: scf-credentials
-type: Opaque
-data:
-${scf_secrets}
-EOT
+export KUBECONFIG="/var/vcap/jobs/opi/config/kube.conf"
+kubectl="/var/vcap/packages/kubectl/bin/kubectl"
 
-$kubectl get namespace "<%= p("scf.eirini.namespace") %>" || $kubectl create namespace "<%= p("scf.eirini.namespace") %>"
+$kubectl apply -f <($kubectl create secret generic loggregator-tls-certs-secret \
+  --dry-run \
+  --save-config \
+  --from-file=internal-ca-cert=/var/vcap/jobs/configure-eirini/config/loggregator-ca.crt \
+  --from-file=loggregator-agent-cert=/var/vcap/jobs/configure-eirini/config/loggregator-agent.crt \
+  --from-file=loggregator-agent-cert-key=/var/vcap/jobs/configure-eirini/config/loggregator-agent.key \
+  -o yaml)
 
-$kubectl apply -f secret.yml --namespace "<%= p("scf.eirini.namespace") %>"
-
-status "Setting up fluentd configuration"
+echo "Setting up fluentd configuration"
 $kubectl apply -f /var/vcap/jobs/configure-eirini/config/fluentd-configmap.yaml
 
-status "Setting up Eirini daemonsets"
+echo "Setting up Eirini daemonsets"
 $kubectl apply -f /var/vcap/jobs/configure-eirini/config/eirini-daemonset.yaml


### PR DESCRIPTION
Hi SUSE friends,

We took a look at the configure-eirini errand and modified it until we could get it to work for a bosh-deployed environment. The state of this PR is what we know works for us (i.e., bosh-deployed env).

This PR isn't meant to be merged as-is,  but we thought it'd be a nice starting point to have a discussion of what's needed for both the BOSH and fissilized worlds. We pulled out things that you may need that we didn't in our environment, but the pulled-out components could be wrapped in some conditional logic if they're needed when running on k8s.

Feel free to make comments, and we can have a couple rounds of back and forth (and potentially video chat) to find a good spot to land with this.

Thanks,
Jen & @jpalermo