### PR TITLE
Mount the needed files to talk to kube api from within the eirini pod

### DIFF
--- a/jobs/eirini-extensions/templates/bpm.yml.erb
+++ b/jobs/eirini-extensions/templates/bpm.yml.erb
@@ -8,3 +8,14 @@ processes:
       OPERATOR_WEBHOOK_HOST: "<%= p("eirini-extensions.operator_webhook_host") %>"
       OPERATOR_WEBHOOK_PORT: "<%= p("eirini-extensions.operator_webhook_port") %>"
       NAMESPACE: "<%= p("eirini-extensions.namespace") %>"
+    <% if properties.opi&.k8s&.host_url.nil? %>
+    # The ServiceAccount admission controller has to be enabled.
+    # https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
+    additional_volumes:
+    - path: /var/run/secrets/kubernetes.io/serviceaccount/token
+      mount_only: true
+    - path: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      mount_only: true
+    - path: /var/run/secrets/kubernetes.io/serviceaccount/namespace
+      mount_only: true
+    <% end %>

--- a/jobs/eirini-persi-broker/templates/bpm.yml.erb
+++ b/jobs/eirini-persi-broker/templates/bpm.yml.erb
@@ -6,3 +6,14 @@ processes:
       KUBERNETES_SERVICE_HOST: "<%= p("eirini-persi-broker.kube_service_host") %>"
       KUBERNETES_SERVICE_PORT: "<%= p("eirini-persi-broker.kube_service_port") %>"
       BROKER_CONFIG_PATH: /var/vcap/jobs/eirini-persi-broker/config/eirini-persi-broker.yml
+    <% if properties.opi&.k8s&.host_url.nil? %>
+    # The ServiceAccount admission controller has to be enabled.
+    # https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
+    additional_volumes:
+    - path: /var/run/secrets/kubernetes.io/serviceaccount/token
+      mount_only: true
+    - path: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      mount_only: true
+    - path: /var/run/secrets/kubernetes.io/serviceaccount/namespace
+      mount_only: true
+    <% end %>

--- a/jobs/opi/templates/bpm.yml.erb
+++ b/jobs/opi/templates/bpm.yml.erb
@@ -7,3 +7,14 @@ processes:
     env:
       KUBERNETES_SERVICE_HOST: "<%= p("opi.kube_service_host") %>"
       KUBERNETES_SERVICE_PORT: "<%= p("opi.kube_service_port") %>"
+    <% if properties.opi&.k8s&.host_url.nil? %>
+    # The ServiceAccount admission controller has to be enabled.
+    # https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
+    additional_volumes:
+    - path: /var/run/secrets/kubernetes.io/serviceaccount/token
+      mount_only: true
+    - path: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      mount_only: true
+    - path: /var/run/secrets/kubernetes.io/serviceaccount/namespace
+      mount_only: true
+    <% end %>


### PR DESCRIPTION
These files are needed in order for a process in the the bpm container to be able to talk to the kube api. 
They will only exist if the admission controller "ServiceAccount" is enabled on the kube apiserver.

https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod