### PR TITLE
Creates system service account & namespace

### DIFF
--- a/jobs/configure-eirini-bosh/templates/eirini-daemonset.yaml.erb
+++ b/jobs/configure-eirini-bosh/templates/eirini-daemonset.yaml.erb
@@ -14,7 +14,7 @@ spec:
       labels:
         name: eirini-loggregator-fluentd
     spec:
-      serviceAccountName: "<%= p('eirini.service_account') %>"
+      serviceAccountName: <%= p('opi.system_namespace') %>-service-account
       initContainers:
       - name: config-copier
         image: "<%= p('eirini.config_copier_image') %>"

--- a/jobs/configure-eirini-bosh/templates/run.erb
+++ b/jobs/configure-eirini-bosh/templates/run.erb
@@ -10,6 +10,14 @@ kubectl=/var/vcap/packages/kubectl/bin/kubectl
 
 $kubectl apply -f <($kubectl create namespace "<%= p('opi.system_namespace') %>" --dry-run --save-config -o yaml)
 
+$kubectl apply -f <($kubectl create serviceaccount --namespace="<%= p('opi.system_namespace') %>" "<%= p('opi.system_namespace') %>-service-account" --dry-run --save-config -o yaml)
+
+$kubectl apply -f <($kubectl create clusterrolebinding \
+       "<%= p('opi.system_namespace') %>-service-account-cluster-binding" \
+       --clusterrole=cluster-admin \
+       --serviceaccount="<%= p('opi.system_namespace') %>:<%= p('opi.system_namespace') %>-service-account" \
+       -o yaml --save-config --dry-run)
+
 $kubectl apply -f <($kubectl create secret generic loggregator-tls-certs-secret \
   -n "<%= p('opi.system_namespace') %>" \
   --dry-run \


### PR DESCRIPTION
This creates a non-default namespace where we can put component and workloads into, so that system resources and app instances will be run in separate non-default namespaces.

Signed-off-by: Josh Russett <jrussett@pivotal.io>