### PR TITLE
Add default for opi images

### DIFF
--- a/jobs/opi/spec
+++ b/jobs/opi/spec
@@ -48,10 +48,13 @@ properties:
   opi.cc_uploader_ip:
     description: "IP Address of the Cloud Controller uploader"
   opi.downloader_image:
+    default: ""
     description: "Downloads app-bits and buildpacks from the bits-service"
   opi.uploader_image:
+    default: ""
     description: "Uploads the Droplet to the bits-service"
   opi.executor_image:
+    default: ""
     description: "Executes the buildpackapplifecyle to build a Droplet"
   opi.metrics_source_address:
     description: "Source URL for metrics"


### PR DESCRIPTION
Add default value for opi images, so that `jobs/opi/templates/opi.yml.erb` won't error out if the images are not provided.