### PR TITLE
Add separate property to make cert copier optional

### DIFF
--- a/jobs/configure-eirini-scf/spec
+++ b/jobs/configure-eirini-scf/spec
@@ -17,6 +17,10 @@ properties:
     description: "The PEM-encoded private key for internal cloud controller uploader traffic."
   eirini.cert_copier_image:
     description: "The docker image used by Eirini to register the image registry CA cert with Docker, on each Kubernetes node"
+  eirini.run_cert_copier:
+    description: "Controls if the cert copier daemonset should be created."
+    default: true
+
   opi.cc_cert:
     description: "Cloud Controller cert"
   opi.cc_key:

--- a/jobs/configure-eirini-scf/templates/run.erb
+++ b/jobs/configure-eirini-scf/templates/run.erb
@@ -20,8 +20,7 @@ $kubectl create secret generic "<%= p("opi.certs_secret_name") %>" -n "<%= p("op
   --from-literal=cc-uploader-crt-key='<%= p("capi.cc_uploader.mutual_tls.server_key") %>' \
   --from-literal=internal-ca-cert='<%= p("opi.cc_ca") %>'
 
-
-<% if_p("eirini.cert_copier_image") do %>
+<% if_p("eirini.run_cert_copier") do %>
 
 status "Copying Bits registry certificate on the host"
 $kubectl apply -f /var/vcap/jobs/configure-eirini-scf/config/eirini-cert-copier.yaml


### PR DESCRIPTION
Setting `cert_copier-image` to nil or empty string doesn't work because the SCF role manifest marks it as an image name, so it will still be expanded with the configured registry and org.