### PR TITLE
Add basic auth support for OCI registry

### DIFF
--- a/jobs/opi/spec
+++ b/jobs/opi/spec
@@ -2,6 +2,8 @@
 name: opi
 
 templates:
+  pre-start.erb: bin/pre-start
+
   bpm.yml.erb: config/bpm.yml
   opi.yml.erb: config/opi.yml
   kube.conf.erb: config/kube.conf
@@ -31,6 +33,10 @@ properties:
     description: "Kubernetes service port. Should be set to the value of KUBERNETES_SERVICE_PORT."
   opi.registry_address:
     description: "Address of registry"
+  opi.registry_username:
+    description: "Basic auth username for registry"
+  opi.registry_password:
+    description: "Basic auth user credentials for registry"
   opi.eirini_address:
     description: "Address of Eirini"
   opi.nats_password:

--- a/jobs/opi/templates/opi.yml.erb
+++ b/jobs/opi/templates/opi.yml.erb
@@ -10,6 +10,7 @@ opi:
   cc_uploader_ip: <%= p("opi.cc_uploader_ip") %>
 
   registry_address: <%= p("opi.registry_address") %>
+  registry_secret_name: bits-service-registry-secret
   eirini_address: <%= p("opi.eirini_address", "http://" + spec.ip + ":8085") %>
   downloader_image: <%= p("opi.downloader_image") %>
   uploader_image: <%= p("opi.uploader_image") %>

--- a/jobs/opi/templates/pre-start.erb
+++ b/jobs/opi/templates/pre-start.erb
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+job_dir=/var/vcap/jobs/opi
+export KUBECONFIG=${job_dir}/config/kube.conf
+kubectl=/var/vcap/packages/kubectl/bin/kubectl
+
+$kubectl apply -f <($kubectl create secret docker-registry bits-service-registry-secret \
+  -n "<%= p('opi.kube_namespace') %>" \
+  --dry-run \
+  --save-config \
+  --docker-server="<%= p('opi.registry_address') %>"  \
+  --docker-username="<%= p('opi.registry_username') %>"  \
+  --docker-password="<%= p('opi.registry_password') %>" \
+  -o yaml)

--- a/operations/add-eirini.yml
+++ b/operations/add-eirini.yml
@@ -23,6 +23,8 @@
           kube_service_host: ""
           kube_service_port: ""
           registry_address: registry.((system_domain))
+          registry_username: admin
+          registry_password: ((bits_service_signing_password))
           nats_password: ((nats_password))
           nats_ip: q-s0.nats.default.cf.bosh
           certs_secret_name: eirini-staging-secret
@@ -130,10 +132,9 @@
   path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/rootfs?/blobstore_type?
   value: local
 
-# pin to version 2.28.0 of bits-service until we've added support for auth with bits-service registry
 - type: replace
   path: /releases/name=bits-service/version?
-  value: "2.28.0"
+  value: latest
 - type: replace
   path: /releases/name=eirini?/version?
   value: latest

--- a/plan-patches/shared/deploy.sh
+++ b/plan-patches/shared/deploy.sh
@@ -12,8 +12,7 @@ CF_DEPLOYMENT_PATH="$(realpath -e ${1})"
 EIRINI_BOSH_RELEASE_PATH="$(realpath -e ${2})"
 
 bosh upload-release https://bosh.io/d/github.com/cloudfoundry-community/eirini-bosh-release
-# pin to version 2.28.0 of bits-service until we've added support for auth with bits-service registry
-bosh upload-release https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=2.28.0
+bosh upload-release https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release
 
 bosh -d cf deploy "${CF_DEPLOYMENT_PATH}/cf-deployment.yml" --no-redact \
   -o "${CF_DEPLOYMENT_PATH}/operations/use-compiled-releases.yml" \


### PR DESCRIPTION
Necessary to use Eirini with the latest version of the bits-service BOSH release (`2.29.0`) since it now enforces using basic auth to pull images from its Docker registry endpoints. 

- Added pre-start script to create necessary Kubernetes secret to provide basic auth credentials when pulling app images from an OCI registry
- Unpin bits-service-release version in shared deploy script

Jwal  + @madamkiwi 