### PR TITLE
Update `eirini_address` calculation in OPI job

### DIFF
--- a/jobs/opi/templates/opi.yml.erb
+++ b/jobs/opi/templates/opi.yml.erb
@@ -11,7 +11,7 @@ opi:
 
   registry_address: <%= p("opi.registry_address") %>
   registry_secret_name: bits-service-registry-secret
-  eirini_address: <%= p("opi.eirini_address", "http://" + spec.ip + ":8085") %>
+  eirini_address: <%= p("opi.eirini_address", "https://" + spec.ip + "opi.tls_port") %>
   downloader_image: <%= p("opi.downloader_image") %>
   uploader_image: <%= p("opi.uploader_image") %>
   executor_image: <%= p("opi.executor_image") %>


### PR DESCRIPTION
Properly construct the `eirini_address` URI with HTTPS and the
user-configurable TLS port when users do not supply an explicit value.

This change helps ensure that Eirini-native staging callbacks will work
once it's been enabled.



Thanks!
Josh + @jenspinney 
