### PR TITLE
Fix K8s service account token fetch, director creation in GCP plan-patch

### DIFF
--- a/plan-patches/gcp/terraform/outputs.tf
+++ b/plan-patches/gcp/terraform/outputs.tf
@@ -1,5 +1,5 @@
-output "k8s_service_token" {
-  value = "${data.kubernetes_secret.k8s_service_token.data.token}"
+output "k8s_service_account_data" {
+  value = "${data.kubernetes_secret.k8s_service_token.data}"
 }
 
 output "k8s_host_url" {

--- a/plan-patches/shared/create-director-override.sh
+++ b/plan-patches/shared/create-director-override.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 SCRIPT_DIR=$(dirname "$(readlink \"$0\")")
-echo "$SCRIPT_DIR/create-director.sh"
+"${SCRIPT_DIR}/create-director.sh"
 
 bosh_director_name="$(bbl outputs | bosh int - --path=/director_name)"
 k8s_host_url="$(bbl outputs | bosh int - --path=/k8s_host_url)"
 k8s_service_username="$(bbl outputs | bosh int - --path=/k8s_service_username)"
-k8s_service_token="$(bbl outputs | bosh int - --path=/k8s_service_token)"
+k8s_service_token="$(bbl outputs | bosh int - --path=/k8s_service_account_data/token)"
 k8s_ca="$(bbl outputs | bosh int - --path=/k8s_ca)"
 
 eval "$(bbl print-env -s ${BBL_STATE_DIR})"


### PR DESCRIPTION
- Fixes race in terraform data provider when fetching a token for a service account on the Kubernetes cluster
- Actually executes the create-director script

fixes:

> Error: Error running plan: 1 error(s) occurred:
>
> * output.k8s_service_token: Resource `'data.kubernetes_secret.k8s_service_token'` does not have attribute `'data.token'` for variable `'data.kubernetes_secret.k8s_service_token.data.token'`
