### PR TITLE
Create workloads namespace during OPI pre-start

### DIFF
--- a/jobs/configure-eirini-bosh/templates/run.erb
+++ b/jobs/configure-eirini-bosh/templates/run.erb
@@ -8,8 +8,6 @@ job_dir=/var/vcap/jobs/configure-eirini-bosh
 export KUBECONFIG=${job_dir}/config/kube.conf
 kubectl=/var/vcap/packages/kubectl/bin/kubectl
 
-$kubectl apply -f <($kubectl create namespace "<%= p('opi.workloads_namespace') %>" --dry-run --save-config -o yaml)
-
 $kubectl apply -f <($kubectl create secret generic loggregator-tls-certs-secret \
   -n "<%= p('opi.system_namespace') %>" \
   --dry-run \

--- a/jobs/opi/templates/pre-start.erb
+++ b/jobs/opi/templates/pre-start.erb
@@ -6,6 +6,8 @@ job_dir=/var/vcap/jobs/opi
 export KUBECONFIG=${job_dir}/config/kube.conf
 kubectl=/var/vcap/packages/kubectl/bin/kubectl
 
+$kubectl apply -f <($kubectl create namespace "<%= p('opi.kube_namespace') %>" --dry-run --save-config -o yaml)
+
 $kubectl apply -f <($kubectl create secret docker-registry bits-service-registry-secret \
   -n "<%= p('opi.kube_namespace') %>" \
   --dry-run \


### PR DESCRIPTION
- As part of this commit, 9f9bda32943881ea8a95eaa3a7716476f1580a5c, we
added functionality for connecting to the OCI registry with basic auth,
which requires the presence of a k8s docker-registry secret in the workloads namespace
- Previously we created the workloads namespace as part of the
configure-eirini-bosh errand but now the creation of that namespace must
happen before job deployment otherwise the job will fail to start

@jimmykarily @mudler Could we please also cut a new release? The previous release, `0.0.16`, is broken from the changes we introduced and are now attempting to fix with this PR.

Thanks,

Josh + @jspawar  

