### PR TITLE
Create secret for native staging

### DIFF
--- a/jobs/configure-eirini-bosh/spec
+++ b/jobs/configure-eirini-bosh/spec
@@ -17,6 +17,7 @@ templates:
   loggregator-ca.crt.erb: config/loggregator-ca.crt
   loggregator-agent.crt.erb: config/loggregator-agent.crt
   loggregator-agent.key.erb: config/loggregator-agent.key
+  eirini-staging-secret.yaml.erb: config/eirini-staging-secret.yaml
 
 properties:
   eirini.loggregator_agent_image:
@@ -43,6 +44,9 @@ properties:
     description: "Kubernetes namespace where to run deployments and tasks"
   opi.system_namespace:
     description: "Kubernetes namespace where to deploy Eirini components"
+  opi.certs_secret_name:
+    description: "Name to use for Kubernetes secret used by Eirini for staging"
+    default: "cf_secrets"
 
   loggregator.ca-cert:
     description: "CA certificate that is signing the server certificate of the target doppler and loggregator agent"
@@ -50,6 +54,18 @@ properties:
     description: "Certificate of the loggregator agent"
   loggregator.agent-cert-key:
     description: "Private key of the loggregator agent"
+
+  cc.ca_cert:
+    description: "CA certificate that is signing the server certificate of the Cloud Controller"
+  cc.server_cert:
+    description: "Certificate of the Cloud Controller"
+  cc.server_cert_key:
+    description: "Private key of the Cloud Controller"
+
+  eirini.server_cert:
+    description: "TLS certificate for Eirini server"
+  eirini.server_key:
+    description: "Private key associated with TLS certificate for Eirini server"
 
   errand.daemonset_rollout_timeout:
     description: "String (e.g., '3s', '4m', '2h') indicating the time to allow the Eirini daemonset rollout to become healthy. The errand will exit with an error if the rollout takes longer than this time."

--- a/jobs/configure-eirini-bosh/templates/eirini-staging-secret.yaml.erb
+++ b/jobs/configure-eirini-bosh/templates/eirini-staging-secret.yaml.erb
@@ -1,0 +1,20 @@
+<%
+    # Takes a string and returns a base64 encoded string
+    # 'm' says base64 and the '0' means do not add newlines.
+    def encode64(bin)
+      [bin].pack("m0")
+    end
+%>
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <%= p("opi.certs_secret_name") %>
+type: Opaque
+data:
+  cc-server-crt: <%= encode64(p("cc.server_cert")) %>
+  cc-server-crt-key: <%= encode64(p("cc.server_cert_key")) %>
+  cc-uploader-crt: <%= encode64(p("cc.server_cert")) %>
+  cc-uploader-crt-key: <%= encode64(p("cc.server_cert_key")) %>
+  internal-ca-cert: <%= encode64(p("cc.ca_cert")) %>
+  eirini-client-crt: <%= encode64(p("eirini.server_cert")) %>
+  eirini-client-crt-key: <%= encode64(p("eirini.server_key")) %>

--- a/jobs/configure-eirini-bosh/templates/run.erb
+++ b/jobs/configure-eirini-bosh/templates/run.erb
@@ -8,6 +8,7 @@ job_dir=/var/vcap/jobs/configure-eirini-bosh
 export KUBECONFIG=${job_dir}/config/kube.conf
 kubectl=/var/vcap/packages/kubectl/bin/kubectl
 
+echo "Creating loggregator secret"
 $kubectl apply -f <($kubectl create secret generic loggregator-tls-certs-secret \
   -n "<%= p('opi.system_namespace') %>" \
   --dry-run \
@@ -16,6 +17,9 @@ $kubectl apply -f <($kubectl create secret generic loggregator-tls-certs-secret 
   --from-file=loggregator-agent-cert=${job_dir}/config/loggregator-agent.crt \
   --from-file=loggregator-agent-cert-key=${job_dir}/config/loggregator-agent.key \
   -o yaml)
+
+echo "Creating eirini staging secret"
+$kubectl apply -f ${job_dir}/config/eirini-staging-secret.yaml -n "<%= p('opi.workloads_namespace') %>"
 
 echo "Setting up fluentd configuration"
 $kubectl apply -f ${job_dir}/config/fluentd-configmap.yaml -n "<%= p('opi.system_namespace') %>"


### PR DESCRIPTION
In order to enable Eirini native staging, a secret needs to be created. This makes the configure-eirini-bosh job create that secret.

- Six new properties needed to be added to the job spec
- One new template for the YAML to kubectl apply to create the secret
- Secret name is configurable so that it will match the opi job's expected secret name

Leah & @jrussett 