### PR TITLE
Fix port in auto-generated Eirini address

### DIFF
--- a/jobs/opi/templates/opi.yml.erb
+++ b/jobs/opi/templates/opi.yml.erb
@@ -11,7 +11,7 @@ opi:
 
   registry_address: <%= p("opi.registry_address") %>
   registry_secret_name: bits-service-registry-secret
-  eirini_address: <%= p("opi.eirini_address", "https://" + spec.ip + "opi.tls_port") %>
+  eirini_address: <%= p("opi.eirini_address", "https://" + spec.ip + opi.tls_port) %>
   downloader_image: <%= p("opi.downloader_image") %>
   uploader_image: <%= p("opi.uploader_image") %>
   executor_image: <%= p("opi.executor_image") %>


### PR DESCRIPTION
If the `opi.eirini_address` property is not explicitly specified, we use the IP of the current BOSH VM. We previously made a change to have this auto-generated address use `https` instead of `http`. In doing so, we accidentally appended the literal string "opi.tls_port" instead of the value of `opi.tls_port`.

This commit fixes that mistake.