### PR TITLE
overwrite certs_secret if it already exists

### DIFF
--- a/jobs/configure-eirini-scf/templates/run.erb
+++ b/jobs/configure-eirini-scf/templates/run.erb
@@ -17,7 +17,8 @@ $kubectl create secret generic "<%= p("opi.certs_secret_name") %>" -n "<%= p("op
   --from-literal=cc-server-crt-key='<%= p("opi.cc_key") %>' \
   --from-literal=cc-uploader-crt='<%= p("capi.cc_uploader.mutual_tls.server_cert") %>' \
   --from-literal=cc-uploader-crt-key='<%= p("capi.cc_uploader.mutual_tls.server_key") %>' \
-  --from-literal=internal-ca-cert='<%= p("opi.cc_ca") %>'
+  --from-literal=internal-ca-cert='<%= p("opi.cc_ca") %>' \
+  --dry-run -o json | $kubectl apply -f -
 
 <% if_p("eirini.cert_copier_image") do %>
 


### PR DESCRIPTION
The script in `run.erb` will not update the certs_secret if it already exists.
We use the `--dry-run` feature of `kubectl` to generate a json and apply it afterwards, which will work for create and update scenario.

BTW: maybe it would be a good idea to also activate errexit (`set -e`) and/or similar options.