### PR TITLE
Add required properties to add-eirini opsfile

### DIFF
--- a/operations/add-eirini.yml
+++ b/operations/add-eirini.yml
@@ -64,9 +64,17 @@
           doppler_address_with_az: doppler.service.cf.internal:8082
           fluentd_image: eirini/loggregator-fluentd
           loggregator_agent_image: loggregator/agent
+          server_cert: ((eirini_tls_server_cert.certificate))
+          server_key: ((eirini_tls_server_cert.private_key))
+          client_ca: ((service_cf_internal_ca.certificate))
         opi:
+          certs_secret_name: eirini-staging-secret
           workloads_namespace: cf-workloads
           system_namespace: cf-system
+        cc:
+          server_cert_key: ((cc_bridge_tps.certificate))
+          server_cert: ((cc_bridge_tps.private_key))
+          ca_cert: ((service_cf_internal_ca.certificate))
         loggregator:
           agent-cert: ((loggregator_tls_agent.certificate))
           agent-cert-key: ((loggregator_tls_agent.private_key))


### PR DESCRIPTION
This fixes a deployment failure introduced by ef79ee34acc0c34cedbca787ce931cefddfaddd7
```
Task 1535 | 21:55:14 | Preparing deployment: Rendering templates (00:00:23)
                    L Error: Unable to render instance groups for deployment. Errors are:
  - Unable to render jobs for instance group 'eirini'. Errors are:
    - Unable to render templates for job 'configure-eirini-bosh'. Errors are:
      - Error filling in template 'eirini-staging-secret.yaml.erb' (line 14: Can't find property '["cc.server_cert"]')
```

Hat tip to @cwlbraa for the fix