### PR TITLE
Removed cc_uploader_ip property from opi

### DIFF
--- a/jobs/opi/spec
+++ b/jobs/opi/spec
@@ -52,8 +52,6 @@ properties:
     default: "cf_secrets"
   opi.cc_internal_api:
     description: "Internal URL for the Cloud Controller"
-  opi.cc_uploader_ip:
-    description: "IP Address of the Cloud Controller uploader"
   opi.downloader_image:
     default: ""
     description: "Downloads app-bits and buildpacks from the bits-service"

--- a/jobs/opi/templates/opi.yml.erb
+++ b/jobs/opi/templates/opi.yml.erb
@@ -7,7 +7,6 @@ opi:
 
   cc_certs_secret_name: <%= p("opi.certs_secret_name") %>
   cc_internal_api: <%= p("opi.cc_internal_api") %>
-  cc_uploader_ip: <%= p("opi.cc_uploader_ip") %>
 
   registry_address: <%= p("opi.registry_address") %>
   registry_secret_name: bits-service-registry-secret

--- a/operations/add-eirini.yml
+++ b/operations/add-eirini.yml
@@ -29,7 +29,6 @@
           nats_ip: q-s0.nats.default.cf.bosh
           certs_secret_name: eirini-staging-secret
           cc_internal_api: https://cloud-controller-ng.service.cf.internal:9023
-          cc_uploader_ip: ""
           eirini_address: https://eirini.service.cf.internal:8484
           downloader_image: "eirini/recipe-downloader"
           uploader_image: "eirini/recipe-uploader"


### PR DESCRIPTION
The current Eirini version doesn't have the cc_uploader_ip as it was
removed on the commit:
https://github.com/cloudfoundry-incubator/eirini/commit/c23632d3b2a56e899db14cd5f6f0bed97bd00213