### PR TITLE
Configure fluentd not to replace dots

### DIFF
--- a/jobs/configure-eirini-bosh/templates/fluentd-configmap.yaml.erb
+++ b/jobs/configure-eirini-bosh/templates/fluentd-configmap.yaml.erb
@@ -21,6 +21,7 @@ data:
     </source>
     <filter kubernetes.**>
       @type kubernetes_metadata
+      de_dot false
     </filter>
     <match **>
       type loggregator


### PR DESCRIPTION
Logging for cf depends on the label `cloudfoundry.org/app_guid`.  Without this change, `fluentd` replaces the dots with underscores, resulting in the label key being transformed to `cloudfoundry_org/app_guid` and thus not being selected properly.